### PR TITLE
Added parameter to set lower_case_table_names option.

### DIFF
--- a/openshift_resources/db-templates/mariadb-ephemeral-template.json
+++ b/openshift_resources/db-templates/mariadb-ephemeral-template.json
@@ -190,6 +190,12 @@
       "required": true
     },
     {
+      "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+      "displayName": "MariaDB lower case table names",
+      "description": "Sets how table and database names are compared.",
+      "value": "0"
+    },
+    {
       "name": "MYSQL_INNODB_FLUSH_LOG_AT_TRS_COMMIT",
       "displayName": "MariaDB TX log flush policy",
       "description": "Sets policy for when transaction logs are flushed to disk",

--- a/openshift_resources/db-templates/mariadb-persistent-template.json
+++ b/openshift_resources/db-templates/mariadb-persistent-template.json
@@ -214,6 +214,12 @@
       "required": true
     },
     {
+      "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+      "displayName": "MariaDB lower case table names",
+      "description": "Sets how table and database names are compared.",
+      "value": "0"
+    },
+    {
       "name": "MYSQL_INNODB_FLUSH_LOG_AT_TRS_COMMIT",
       "displayName": "MariaDB TX log flush policy",
       "description": "Sets policy for when transaction logs are flushed to disk",

--- a/openshift_resources/db-templates/mysql-ephemeral-template.json
+++ b/openshift_resources/db-templates/mysql-ephemeral-template.json
@@ -212,6 +212,12 @@
       "required": true
     },
     {
+      "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+      "displayName": "MySQL lower case table names",
+      "description": "Sets how table and database names are compared.",
+      "value": "0"
+    },
+    {
       "name": "MYSQL_INNODB_FLUSH_LOG_AT_TRS_COMMIT",
       "displayName": "MariaDB TX log flush policy",
       "description": "Sets policy for when transaction logs are flushed to disk",

--- a/openshift_resources/db-templates/mysql-persistent-template.json
+++ b/openshift_resources/db-templates/mysql-persistent-template.json
@@ -214,6 +214,12 @@
       "required": true
     },
     {
+      "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+      "displayName": "MySQL lower case table names",
+      "description": "Sets how table and database names are compared.",
+      "value": "0"
+    },
+    {
       "name": "MYSQL_INNODB_FLUSH_LOG_AT_TRS_COMMIT",
       "displayName": "MariaDB TX log flush policy",
       "description": "Sets policy for when transaction logs are flushed to disk",


### PR DESCRIPTION
This adds a parameter to the openshift db templates to allow setting the lower_case_table_names server option which is already supported by the docker images.
