### PR TITLE
User lower case table names param

### DIFF
--- a/openshift_resources/db-templates/mariadb-ephemeral-template.json
+++ b/openshift_resources/db-templates/mariadb-ephemeral-template.json
@@ -106,6 +106,10 @@
                     "value": "${MYSQL_DATABASE}"
                   },
                   {
+                    "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+                    "value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
+                  },
+                  {
                     "name": "MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT",
                     "value": "${MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT}"
                   },

--- a/openshift_resources/db-templates/mariadb-persistent-template.json
+++ b/openshift_resources/db-templates/mariadb-persistent-template.json
@@ -123,6 +123,10 @@
                     "value": "${MYSQL_DATABASE}"
                   },
                   {
+                    "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+                    "value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
+                  },
+                  {
                     "name": "MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT",
                     "value": "${MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT}"
                   },

--- a/openshift_resources/db-templates/mysql-ephemeral-template.json
+++ b/openshift_resources/db-templates/mysql-ephemeral-template.json
@@ -120,6 +120,10 @@
                     "value": "${MYSQL_DATABASE}"
                   },
                   {
+                    "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+                    "value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
+                  },
+                  {
                     "name": "MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT",
                     "value": "${MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT}"
                   },

--- a/openshift_resources/db-templates/mysql-persistent-template.json
+++ b/openshift_resources/db-templates/mysql-persistent-template.json
@@ -123,6 +123,10 @@
                     "value": "${MYSQL_DATABASE}"
                   },
                   {
+                    "name": "MYSQL_LOWER_CASE_TABLE_NAMES",
+                    "value": "${MYSQL_LOWER_CASE_TABLE_NAMES}"
+                  },
+                  {
                     "name": "MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT",
                     "value": "${MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT}"
                   },


### PR DESCRIPTION
The template parameter MYSQL_LOWER_CASE_TABLE_NAMES was not being added to the containers
environment.  This patch fixes that.
